### PR TITLE
Update ClickToChange.js

### DIFF
--- a/lib/events/ClickToChange.js
+++ b/lib/events/ClickToChange.js
@@ -29,7 +29,8 @@ function clickToChangeRadio() {
   if(this.checked)
     return;
   const change = new Event('change', {bubbles: true});
-  change.relatedTarget = this.getRootNode().querySelector('[:checked][group=' + this.getAttribute('group') + ']');
+  const groupItems = this.getRootNode().querySelectorAll(`[checked][name=${groupName}]`);
+  change.relatedTarget = groupItems[groupItems.length-1];
   this.dispatchEvent(change);
 }
 


### PR DESCRIPTION
fixed related target. If we have several inputs in group with "checked" attribute, browser specify only last one and previous just ignore