### PR TITLE
Update EventLoop.js

### DIFF
--- a/lib/platform_bubble/EventLoop.js
+++ b/lib/platform_bubble/EventLoop.js
@@ -114,16 +114,10 @@ function propagateEvent(el) {
 }
 
 function runTimer(el) {
-  let cb = el.cb;
-  if (!cb) {
-    const cbAttribute = el.getAttribute(':cb');
-    if (cbAttribute === '#anonymous')
-      return;
-    cb = window[cbAttribute];
-    if (!cb)
-      throw new Error('renamed setTimeout function between adding the setTimeout and calling the function');
-  }
-  cb.call(); //todo try catch any error and add the error message to the timeout element?
+  let cb = el.cb || window[el.getAttribute(":cb")];
+  let param = el.param;
+  if (cb)
+    param ? cb.call(this, param) : cb.call(); //todo try catch any error and add the error message to the timeout element?
 }
 
 class EventLoop extends HTMLElement {


### PR DESCRIPTION
remove #anonymous function logic, because we prevent it before. Pass params to setTimeouts.